### PR TITLE
Skip yaml files which have a list at the root

### DIFF
--- a/renovate.py
+++ b/renovate.py
@@ -50,6 +50,8 @@ def kind_filter(kind, api_versions):
     """Return a yaml doc filter for specified resource type and version."""
     def func(pair):
         (file, doc) = pair
+        if isinstance(doc, list):
+            return False
         if doc.get("kind") != kind:
             return False
         return doc.get("apiVersion") in api_versions


### PR DESCRIPTION
Prevents `AttributeError: 'list' object has no attribute 'get'`, e.g. when loading a JSON patch in YAML format:

`deployment.patch.yaml`
```
---
- op: add
  path: /spec/template/spec/containers/0/args/-
  value: --default-issuer-name=letsencrypt
- op: add
  path: /spec/template/spec/containers/0/args/-
  value: --default-issuer-kind=ClusterIssuer
- op: add
  path: /spec/template/spec/containers/0/args/-
  value: --default-issuer-group=cert-manager.io
```