### PR TITLE
Tolerate yaml parse errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ with:
   debug: 'no'
   # Do not alter Helm Release files
   dry-run: 'no'
+  # Tolerate yaml files with errors instead of aborting on errors
+  tolerate-yaml-errors: 'no'
 ```
 
 ## Script usage example


### PR DESCRIPTION
This tolerates includes, such as Ansible vault includes, so they get ignored and a warning is printed:

2021-05-23 14:18:03 Renovate Helm Releases WARNING  Skipping '../k8s-gitops/ansible/group_vars/all.yaml': could not determine a constructor for the tag '!vault'
  in "<byte string>", line 52, column 14:
    DOCKER_USER: !vault |
                 ^