### PR TITLE
Handle an empty exclude-folders action option

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -24,4 +24,4 @@ if [ "${TOLERATE_YAML_ERRORS}" = "yes" ]; then
     FLAGS+=("--tolerate-yaml-errors")
 fi
 
-/usr/local/bin/python /app/renovate.py ${FLAGS[@]}
+/usr/local/bin/python /app/renovate.py "${FLAGS[@]}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/sh -l
+#!/bin/bash -l
 
 CLUSTER_PATH="${1}"
 EXCLUDE_FOLDERS="${2}"
@@ -6,22 +6,22 @@ DEBUG="${3}"
 DRY_RUN="${4}"
 TOLERATE_YAML_ERRORS="${5}"
 
-FLAGS="--cluster-path=\"${CLUSTER_PATH}\""
+FLAGS=(--cluster-path="${CLUSTER_PATH}")
 
 if [ -n "${EXCLUDE_FOLDERS}" ]; then
-  FLAGS="$FLAGS --excluded-folders=\"${EXCLUDE_FOLDERS}\""
+  FLAGS+=(--excluded-folders="${EXCLUDE_FOLDERS}")
 fi
 
 if [ "${DEBUG}" = "yes" ]; then
-    FLAGS="$FLAGS --debug"
+    FLAGS+=("--debug")
 fi
 
 if [ "${DRY_RUN}" = "yes" ]; then
-    FLAGS="$FLAGS --dry-run"
+    FLAGS+=("--dry-run")
 fi
 
 if [ "${TOLERATE_YAML_ERRORS}" = "yes" ]; then
-    FLAGS="$FLAGS --tolerate-yaml-errors"
+    FLAGS+=("--tolerate-yaml-errors")
 fi
 
-/usr/local/bin/python /app/renovate.py ${FLAGS}
+/usr/local/bin/python /app/renovate.py ${FLAGS[@]}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,22 +6,22 @@ DEBUG="${3}"
 DRY_RUN="${4}"
 TOLERATE_YAML_ERRORS="${5}"
 
-FLAGS=(--cluster-path="${CLUSTER_PATH}")
+FLAGS="--cluster-path=\"${CLUSTER_PATH}\""
 
-if [ ! -z "${EXCLUDE_FOLDERS}" ]; then
-  FLAGS+=(--excluded-folders=${EXCLUDE_FOLDERS})
+if [ -n "${EXCLUDE_FOLDERS}" ]; then
+  FLAGS="$FLAGS --excluded-folders=\"${EXCLUDE_FOLDERS}\""
 fi
 
 if [ "${DEBUG}" = "yes" ]; then
-    FLAGS+=("--debug")
+    FLAGS="$FLAGS --debug"
 fi
 
 if [ "${DRY_RUN}" = "yes" ]; then
-    FLAGS+=("--dry-run")
+    FLAGS="$FLAGS --dry-run"
 fi
 
 if [ "${TOLERATE_YAML_ERRORS}" = "yes" ]; then
-    FLAGS+=("--tolerate-yaml-errors")
+    FLAGS="$FLAGS --tolerate-yaml-errors"
 fi
 
-/usr/local/bin/python /app/renovate.py ${FLAGS[@]}
+/usr/local/bin/python /app/renovate.py ${FLAGS}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,22 +6,22 @@ DEBUG="${3}"
 DRY_RUN="${4}"
 TOLERATE_YAML_ERRORS="${5}"
 
+FLAGS=(--cluster-path="${CLUSTER_PATH}")
+
+if [ ! -z "${EXCLUDE_FOLDERS}" ]; then
+  FLAGS+=(--excluded-folders=${EXCLUDE_FOLDERS})
+fi
+
 if [ "${DEBUG}" = "yes" ]; then
-    DEBUG="--debug"
-else
-    DEBUG=""
+    FLAGS+=("--debug")
 fi
 
 if [ "${DRY_RUN}" = "yes" ]; then
-    DRY_RUN="--dry-run"
-else
-    DRY_RUN=""
+    FLAGS+=("--dry-run")
 fi
 
 if [ "${TOLERATE_YAML_ERRORS}" = "yes" ]; then
-    TOLERATE_YAML_ERRORS="--tolerate-yaml-errors"
-else
-    TOLERATE_YAML_ERRORS=""
+    FLAGS+=("--tolerate-yaml-errors")
 fi
 
-/usr/local/bin/python /app/renovate.py --cluster-path="${CLUSTER_PATH}" --excluded-folders="${EXCLUDE_FOLDERS}" ${DEBUG} ${DRY_RUN} ${TOLERATE_YAML_ERRORS}
+/usr/local/bin/python /app/renovate.py ${FLAGS[@]}


### PR DESCRIPTION
Restructure how command line flags are handled by appending commands when
they are present and specified to avoid passing an empty string --exclude-folders which excluded everything.

Fixed issue #14