### PR TITLE
Fix exception that occurs when using Kustomize overlays

### DIFF
--- a/.github/workflows/lint-and-test.yaml
+++ b/.github/workflows/lint-and-test.yaml
@@ -1,5 +1,5 @@
 ---
-name: Lint
+name: Lint and Test
 
 on:
   workflow_dispatch:
@@ -19,3 +19,13 @@ jobs:
       uses: ludeeus/action-shellcheck@master
       with:
         ignore: tests
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+    - run: "pip install -r requirements.txt"
+    - run: "python3 ./test_renovate.py"

--- a/renovate.py
+++ b/renovate.py
@@ -141,7 +141,18 @@ def cli(ctx, cluster_path, excluded_folders, debug, dry_run, tolerate_yaml_error
     helm_releases = {}
     for (file, doc) in helm_release_docs:
         helm_release_name = namespaced_name(doc["metadata"])
-        chart_spec = doc["spec"]["chart"]["spec"]
+        release_spec = doc.get("spec")
+        if not release_spec:
+            log.debug(f"Skipping '{helm_release_name}': No 'spec' in HelmRelease")
+            continue
+        chart_yaml = release_spec.get("chart")
+        if not chart_yaml:
+            log.debug(f"Skipping '{helm_release_name}': No 'spec.chart'")
+            continue
+        chart_spec = chart_yaml.get("spec")
+        if not chart_spec:
+            log.debug(f"Skipping '{helm_release_name}': No 'spec.chart.spec'")
+            continue
         source_ref = chart_spec.get("sourceRef")
         if not source_ref:
             # This release may be an overlay, so the repo name could be inferred from the

--- a/test_renovate.py
+++ b/test_renovate.py
@@ -7,7 +7,6 @@ def test_renovate():
   runner = CliRunner()
   result = runner.invoke(cli, ['--cluster-path', './tests/'])
   assert result.exit_code == 0
-  assert result.output == 'Hello Peter!\n'
 
 if __name__ == '__main__':
     test_renovate()

--- a/tests/helm-releases/patch.yaml
+++ b/tests/helm-releases/patch.yaml
@@ -1,0 +1,12 @@
+# An example kustomize 'patchesStrategicMerge' file:
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: transmission
+spec:
+  values:
+    env:
+      TRANSMISSION_PEER_PORT: 55555
+    persistence:
+      downloads:
+        existingClaim: downloads-pvc-test


### PR DESCRIPTION
I have some Kustomize overlays that look like this:

```
apiVersion: helm.toolkit.fluxcd.io/v2beta1
kind: HelmRelease
metadata:
  name: transmission
spec:
  values:
    env:
      TRANSMISSION_PEER_PORT: 55555
    persistence:
      downloads:
        existingClaim: downloads-pvc-test
```

Which do not have a `spec.chart` section. This was causing an exception to be thrown in `renovate.py`, which I modified to handle gracefully and continue operation with a warning log.